### PR TITLE
Add sql.lintOnOpen to the "configuration" in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ SQL extension for coc.nvim
 
 ## Configuration
 
-- `sql.lintOnSave`: Lint sql file on save, default `true`
+- `sql.lintOnOpen`: Lint sql file on opening, default `true`
 - `sql.lintOnChange`: Lint sql file on change, default `true`
+- `sql.lintOnSave`: Lint sql file on save, default `true`
 - `sql.database`: Choose the database syntax flavor, default to `guess`
 
 ## Usage


### PR DESCRIPTION
The description of `sql.lintOnOpen` is missing, so it has been added.