### PR TITLE
[Feat] Added support for per project configuration for sql-format

### DIFF
--- a/src/SQLFormattingEditProvider.ts
+++ b/src/SQLFormattingEditProvider.ts
@@ -21,7 +21,6 @@ async function getConfiguration(uri: DocumentUri): Promise<Object> {
   let previousPath = Uri.parse(uri).fsPath;
   let currentPath = path.dirname(previousPath);
   while ( previousPath !== currentPath && ! fs.existsSync(path.join(currentPath,'.sql-formatter.json')) ) {
-    console.debug(currentPath);
     previousPath = currentPath;
     currentPath = path.resolve(previousPath,'..');
   }
@@ -30,7 +29,6 @@ async function getConfiguration(uri: DocumentUri): Promise<Object> {
   try {
     return JSON.parse(await promisify(fs.readFile)(configPath, { encoding: 'utf-8' }));
   } catch (err) {
-    console.debug(err);
     return workspace.getConfiguration('sql').get('formatOptions', {});
   }
 


### PR DESCRIPTION
I added the support for per project configuration files.

I used the same finding logic as the one used by sql-format when formatting a file.

Tested and works like a charm so far.